### PR TITLE
fix endless redirect on index.html file

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -274,12 +274,7 @@ func (a *Assets) chooseResource(header http.Header, req *http.Request) (string, 
 		header.Set("ETag", calculateEtag(fd.fi))
 	}
 
-	// remove index.html to avoid redirect to / by standard library
-	if strings.HasSuffix(fd.resource, "/"+indexPage) {
-		return fd.resource[0 : len(fd.resource)-len(indexPage)], fd.code
-	}
-
-	return fd.resource, fd.code
+	return strings.TrimSuffix(fd.resource, indexPage), fd.code
 }
 
 // ServeHTTP implements the http.Handler interface. Note that it (a) handles

--- a/assets.go
+++ b/assets.go
@@ -274,6 +274,11 @@ func (a *Assets) chooseResource(header http.Header, req *http.Request) (string, 
 		header.Set("ETag", calculateEtag(fd.fi))
 	}
 
+	// remove index.html to avoid redirect to / by standard library
+	if strings.HasSuffix(fd.resource, "/"+indexPage) {
+		return fd.resource[0 : len(fd.resource)-len(indexPage)], fd.code
+	}
+
 	return fd.resource, fd.code
 }
 

--- a/echo_adapter/handler.go
+++ b/echo_adapter/handler.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blib/servefiles/v3"
 	"github.com/labstack/echo/v4"
-	"github.com/rickb777/servefiles/v3"
 	"github.com/spf13/afero"
 )
 

--- a/echo_adapter/handler_test.go
+++ b/echo_adapter/handler_test.go
@@ -30,12 +30,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rickb777/servefiles/v3/afero2"
+	"github.com/blib/servefiles/v3/afero2"
 
+	"github.com/blib/servefiles/v3/echo_adapter"
+	"github.com/blib/servefiles/v3/testdata"
 	"github.com/labstack/echo/v4"
 	. "github.com/onsi/gomega"
-	"github.com/rickb777/servefiles/v3/echo_adapter"
-	"github.com/rickb777/servefiles/v3/testdata"
 	"github.com/spf13/afero"
 )
 

--- a/example_test.go
+++ b/example_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/spf13/afero"
 
-	"github.com/rickb777/servefiles/v3"
+	"github.com/blib/servefiles/v3"
 )
 
 func ExampleNewAssetHandler() {

--- a/gin_adapter/handler.go
+++ b/gin_adapter/handler.go
@@ -27,8 +27,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/blib/servefiles/v3"
 	"github.com/gin-gonic/gin"
-	"github.com/rickb777/servefiles/v3"
 	"github.com/spf13/afero"
 )
 

--- a/gin_adapter/handler_test.go
+++ b/gin_adapter/handler_test.go
@@ -30,12 +30,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rickb777/servefiles/v3/afero2"
+	"github.com/blib/servefiles/v3/afero2"
 
+	"github.com/blib/servefiles/v3/gin_adapter"
+	"github.com/blib/servefiles/v3/testdata"
 	"github.com/gin-gonic/gin"
 	. "github.com/onsi/gomega"
-	"github.com/rickb777/servefiles/v3/gin_adapter"
-	"github.com/rickb777/servefiles/v3/testdata"
 	"github.com/spf13/afero"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rickb777/servefiles/v3
+module github.com/blib/servefiles/v3
 
 go 1.17
 

--- a/webserver/example.go
+++ b/webserver/example.go
@@ -32,7 +32,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rickb777/servefiles/v3"
+	"github.com/blib/servefiles/v3"
 )
 
 var path = flag.String("path", "..", "directory for the files tp be served")


### PR DESCRIPTION
Requesting dir/index.html file creates infinite redirects 

To reproduce:

static directory contains one file index.html

```
        //go:embed static
        var embededFiles embed.FS

	fsys, _ := fs.Sub(embededFiles, "static")

	h := gin_adapter.NewAssetHandlerIoFS(fsys).
		WithMaxAge(time.Hour).
		HandlerFunc("filepath")

	root.GET("/static/*filepath", h)
	root.HEAD("/static/*filepath", h)

```

if index.html.gz present all is ok